### PR TITLE
Quick fix for missing fields in Details and timestamp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "node-djiparsetxt",
-	"version": "0.1.3",
+	"version": "0.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/services/BinaryParserTable.ts
+++ b/src/services/BinaryParserTable.ts
@@ -44,11 +44,24 @@ export const PARSER_TABLE: IParserLookUpTable = {
 	details: {
 		instance: null,
 		factory: () => {
-			return new Parser()
-				.string("city_part", { length: 20, zeroTerminated: true })
-				.string("street", { length: 20, zeroTerminated: true })
-				.string("city", { length: 20, zeroTerminated: true })
-				.string("area", { length: 20, zeroTerminated: true })
+			const dummy: any = {
+				parser: new Parser()
+				.buffer("city_part", {
+					length: 20,
+					formatter: (dat) => (dat as Buffer).toString("ascii"),
+				})
+				.buffer("street", {
+					length: 20,
+					formatter: (dat) => (dat as Buffer).toString("ascii"),
+				})
+				.buffer("city", {
+					length: 20,
+					formatter: (dat) => (dat as Buffer).toString("ascii"),
+				})
+				.buffer("area", {
+					length: 20,
+					formatter: (dat) => (dat as Buffer).toString("ascii"),
+				})
 				.uint8("is_favorite")
 				.uint8("is_new")
 				.uint8("needs_upload")
@@ -68,11 +81,26 @@ export const PARSER_TABLE: IParserLookUpTable = {
 				.uint32le("video_time")
 				// TODO: finish implementing parser for diff versions
 				.skip(137)
-				.string("aircraft_name", { length: 32, zeroTerminated: true })
-				.string("aircraft_sn", { length: 16, zeroTerminated: true })
-				.string("camera_sn", { length: 16, zeroTerminated: true })
-				.string("rc_sn", { length: 16, zeroTerminated: true })
-				.string("battery_sn", { length: 16, zeroTerminated: true })
+				.string("aircraft_name", { length: 32,
+					formatter: (val: any) => { 
+						return val.replace(/\0.*$/g,'');
+					} })
+				.string("aircraft_sn", { length: 16,
+					formatter: (val: any) => { 
+						return val.replace(/\0.*$/g,'');
+					} })
+				.string("camera_sn", { length: 16,
+					formatter: (val: any) => { 
+						return val.replace(/\0.*$/g,'');
+					}})
+				.string("rc_sn", { length: 16, 
+					formatter: (val: any) => { 
+						return val.replace(/\0.*$/g,'');
+					} })
+				.string("battery_sn", { length: 16, 
+					formatter: (val: any) => { 
+						return val.replace(/\0.*$/g,'');
+					} })
 				.uint8("app_type", {
 					formatter: (appType: any) => appType === 1 ? "IOS" : "Android",
 				})
@@ -81,7 +109,15 @@ export const PARSER_TABLE: IParserLookUpTable = {
 					formatter: (appVersion: any) => {
 						return `${appVersion[0]}.${appVersion[1]}.${appVersion[2]}`;
 					},
-				});
+				})
+			};
+			dummy.parse = (buf: Buffer): any => {
+				const parsed = dummy.parser.parse(buf);
+				const timestamp = bignum_convert_buffer(parsed.timestamp);
+				parsed.timestamp = timestamp.toString();
+				return parsed;
+			};
+			return dummy		
 		},
 	},
 	osd_record: {

--- a/src/services/BinaryParserTable.ts
+++ b/src/services/BinaryParserTable.ts
@@ -82,24 +82,24 @@ export const PARSER_TABLE: IParserLookUpTable = {
 				// TODO: finish implementing parser for diff versions
 				.skip(137)
 				.string("aircraft_name", { length: 32,
-					formatter: (val: any) => { 
-						return val.replace(/\0.*$/g,'');
+					formatter: (val: any) => {
+						return val.replace(/\0.*$/g, "");
 					} })
 				.string("aircraft_sn", { length: 16,
-					formatter: (val: any) => { 
-						return val.replace(/\0.*$/g,'');
+					formatter: (val: any) => {
+						return val.replace(/\0.*$/g, "");
 					} })
 				.string("camera_sn", { length: 16,
-					formatter: (val: any) => { 
-						return val.replace(/\0.*$/g,'');
+					formatter: (val: any) => {
+						return val.replace(/\0.*$/g, "");
 					}})
-				.string("rc_sn", { length: 16, 
-					formatter: (val: any) => { 
-						return val.replace(/\0.*$/g,'');
+				.string("rc_sn", { length: 16,
+					formatter: (val: any) => {
+						return val.replace(/\0.*$/g, "");
 					} })
-				.string("battery_sn", { length: 16, 
-					formatter: (val: any) => { 
-						return val.replace(/\0.*$/g,'');
+				.string("battery_sn", { length: 16,
+					formatter: (val: any) => {
+						return val.replace(/\0.*$/g, "");
 					} })
 				.uint8("app_type", {
 					formatter: (appType: any) => appType === 1 ? "IOS" : "Android",
@@ -109,7 +109,7 @@ export const PARSER_TABLE: IParserLookUpTable = {
 					formatter: (appVersion: any) => {
 						return `${appVersion[0]}.${appVersion[1]}.${appVersion[2]}`;
 					},
-				})
+				}),
 			};
 			dummy.parse = (buf: Buffer): any => {
 				const parsed = dummy.parser.parse(buf);
@@ -117,7 +117,7 @@ export const PARSER_TABLE: IParserLookUpTable = {
 				parsed.timestamp = timestamp.toString();
 				return parsed;
 			};
-			return dummy		
+			return dummy;
 		},
 	},
 	osd_record: {

--- a/src/services/FileInfoService.ts
+++ b/src/services/FileInfoService.ts
@@ -83,7 +83,6 @@ export class FileInfoService extends BaseService {
 		) as BinaryParserService;
 		const detailsParser = parserService.get_parser(ParserTypes.Details);
 		const details = detailsParser.parse(detailsBuf);
-		details.timestamp = bignum_convert_buffer(details.timestamp);
 		return details;
 	}
 }


### PR DESCRIPTION
Changed fields from string to buffer. Don't know why, but this was causing fields to display wrong data. 
Removed `zeroTerminated=true`. This was causing some trouble, completely erasing `camera_sn`
Added a dummy parser to correctly parse out `timestamp` 